### PR TITLE
Fixed typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ NOT_FOUND = lambda item_id="item_id": HTTPException(404, f"Item with {item_id} n
 class ItemResponse(BaseModel):
     field: str | None = None
 
-@view(router)
+@View(router)
 class MyView:
     exceptions = {
         "__all__": [NOT_AUTHORIZED],


### PR DESCRIPTION
the `view` decorator was never imported, so maybe the author wanted to say `View`. :)